### PR TITLE
FYI: Singularity invocation

### DIFF
--- a/preprocess_forrest.sh
+++ b/preprocess_forrest.sh
@@ -2,7 +2,6 @@
 DATA=$1
 for subj in "$DATA"sub*/; do 
   echo $subj
-  docker run -v $subj:$subj rzlim08/minimal_preprocessing "$subj"output $(find $subj/ses-forrestgump/anat/ -name "*T1w.nii.gz") $(find $subj/ses-movie/func/ -name "*bold.nii.gz")
-
+  singularity run -B $subj:$subj min_preproc.simg "$subj"output $(find $subj/ses-movie/anat/ -name "head.nii.gz") $(find $subj/ses-movie/func/  -name "*bold.nii.gz");
 done
 


### PR DESCRIPTION
tagging @rzlim08

I have just met with @rzlim08 to talk about the preprocessing of unmasked studdyforrest data and the warping issues that surfaced between versions of the Docker container (shared in e-mail exchange). This PR shares an alternative container invocation with singularity that I have used to also do the preprocessing on our compute cluster, using the updated container image.

The invocation uses singularity to execute the container. Here is how to get the container:
```
singularity pull docker://adwagner/min_preproc
```

Depending on the singularity version, this will transform the image into a ``.simg`` (Singularity 2.x) or ``.sif`` (Singularity 3.x) file. Our compute cluster has Singularity 2 (2.6.1-dist), hence the command calls a ``.simg`` file.